### PR TITLE
fix(mcp): skill/core list with MCP-valid name/mimeType + empty templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,9 +697,8 @@ dependencies = [
 
 [[package]]
 name = "cloudllm_mcp"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c799da26a873de7725fee798d0319e2932fda232c0da4753da697a3425e61f"
+version = "0.3.6"
+source = "git+https://github.com/Siccmade85/cloudllm?branch=fix%2Fmcp-resource-metadata-wire-format#d9d929ad790e168ce7fd1d2e4c90f0f8c11af0ad"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ crossterm = "0.28"
 ratatui = "0.30.0"
 toml_edit = "0.22.27"
 uuid = { version = "1.22.0", features = ["v4", "serde"] }
-mcp = { package = "cloudllm_mcp", version = "0.3.5" }
+# cloudllm_mcp 0.3.6: MCP-valid ResourceMetadata (name/mimeType/_meta) + empty
+# resources/templates/list. Git pin until 0.3.6 is published to crates.io; then
+# switch back to: mcp = { package = "cloudllm_mcp", version = "0.3.6" }
+mcp = { package = "cloudllm_mcp", git = "https://github.com/Siccmade85/cloudllm", branch = "fix/mcp-resource-metadata-wire-format" }
 axum = { version = "0.8.8", optional = true }
 axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
 if-addrs = { version = "0.15", optional = true }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+0.10.5.51 (unreleased)
+  - fix(mcp): emit MCP-valid `resources/list` for `mentisdb://skill/core`
+    - Pass explicit resource `name = "core"` (required by MCP `BaseMetadata`)
+    - Depends on `cloudllm_mcp` 0.3.6 so wire JSON uses `mimeType` / `_meta`
+      instead of snake_case `mime_type` / `metadata` (fixes FastMCP /
+      AggregateProvider `ListResourcesResult` validation failures)
+    - `resources/templates/list` returns HTTP 200 with empty
+      `resourceTemplates` (stdio path + streamable HTTP via cloudllm_mcp)
+    - Server tests assert `name`, `mimeType`, `_meta.recommended_first`, and
+      empty templates list
+
 0.10.5.50 JUL/13/2026
   - fix(search): default retrieval now excludes superseded, corrected, and
     invalidated thoughts via the live `invalidated_thought_ids` set (query,

--- a/src/bin/mentisdb.rs
+++ b/src/bin/mentisdb.rs
@@ -1265,6 +1265,9 @@ async fn handle_stdio_jsonrpc(line: &str, protocol: &MentisDbMcpProtocol) -> Opt
                 Err(e) => Err(e.to_string()),
             }
         }
+        // FastMCP probes templates after resources/list; return empty OK rather
+        // than method-not-found so mounted clients do not treat this as failure.
+        "resources/templates/list" => Ok(serde_json::json!({ "resourceTemplates": [] })),
         _ => Err(format!("Method not found: {method}")),
     };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2622,6 +2622,7 @@ impl ToolProtocol for MentisDbMcpProtocol {
             MENTISDB_SKILL_RESOURCE_URI,
             "Read this first: the embedded MentisDB operating skill and chain-selection guidance.",
         )
+        .with_name("core")
         .with_mime_type("text/markdown")
         .with_metadata("recommended_first", json!(true))
         .with_metadata("priority", json!(1))])

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -2453,12 +2453,52 @@ async fn live_mcp_server_supports_standard_initialize_and_tools_list() {
     )
     .unwrap();
     let resources = resources_json["result"]["resources"].as_array().unwrap();
-    assert!(resources
+    let skill = resources
         .iter()
-        .any(|resource| resource["uri"] == "mentisdb://skill/core"));
-    assert!(resources
-        .iter()
-        .any(|resource| resource["metadata"]["recommended_first"] == json!(true)));
+        .find(|resource| resource["uri"] == "mentisdb://skill/core")
+        .expect("mentisdb://skill/core listed");
+    // MCP Resource / BaseMetadata: required name + camelCase mimeType; meta in _meta.
+    assert_eq!(skill["name"], "core");
+    assert_eq!(skill["mimeType"], "text/markdown");
+    assert_eq!(skill["_meta"]["recommended_first"], json!(true));
+    assert!(skill.get("mime_type").is_none());
+    assert!(skill.get("metadata").is_none());
+
+    let mut templates_list_request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("content-type", "application/json")
+        .header("MCP-Protocol-Version", "2025-06-18")
+        .body(Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 35,
+                "method": "resources/templates/list",
+                "params": {}
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    templates_list_request
+        .extensions_mut()
+        .insert(ConnectInfo(client_addr));
+    let templates_list = router
+        .clone()
+        .oneshot(templates_list_request)
+        .await
+        .unwrap();
+    assert_eq!(templates_list.status(), StatusCode::OK);
+    let templates_json: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(templates_list.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(templates_json.get("error").is_none());
+    assert_eq!(
+        templates_json["result"]["resourceTemplates"],
+        json!([])
+    );
 
     let mut resource_read_request = Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary

MentisDB `resources/list` for `mentisdb://skill/core` was rejected by FastMCP / AggregateProvider because the payload lacked MCP-required `name` and used snake_case `mime_type` / `metadata` from `cloudllm_mcp` 0.3.5. Cursor then surfaces a misleading "Authorization failed… not found or not authorized" when reading the skill resource through a mount.

This PR:

- Passes explicit `.with_name("core")` on the skill resource
- Depends on `cloudllm_mcp` **0.3.6** wire format (`mimeType`, `_meta`) via git pin to the companion cloudllm PR branch until crates.io publish
- Returns empty `resources/templates/list` on the stdio MCP path (streamable HTTP covered in cloudllm_mcp)
- Tightens `live_mcp_server_supports_standard_initialize_and_tools_list` to assert `name`, `mimeType`, `_meta.recommended_first`, and empty templates

**Depends on:** https://github.com/CloudLLM-ai/cloudllm/pull/55 (`cloudllm_mcp` 0.3.6). After crates.io publish, switch `Cargo.toml` back to `mcp = { package = "cloudllm_mcp", version = "0.3.6" }`.

## Test plan

- [x] `cargo test --features server --test server_tests live_mcp_server_supports_standard_initialize_and_tools_list` (with local path/`git` pin to cloudllm_mcp 0.3.6)
- [ ] Merge + publish cloudllm_mcp 0.3.6
- [ ] Switch MentisDB dep from git pin → crates.io `0.3.6`
- [ ] Release MentisDB; upgrade local daemon; re-probe `resources/list` for `name`/`mimeType`